### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "rss-emitter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Small library which import RSS feeds and emit upon new entries — Edit",
   "main": "lib/index.js",
   "dependencies": {
-    "feedparser": "~0.16.1",
-    "levelup": "~0.12.0",
-    "request": "~2.25.0",
-    "leveldown": "~0.6.2",
-    "underscore": "~1.5.1"
+    "feedparser": "^1.1.3",
+    "leveldown": "^1.4.1",
+    "levelup": "^1.2.1",
+    "request": "^2.61.0",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Mainly because the old leveldown version doesn't seem to compile on newer node versions